### PR TITLE
[Failed] PRG_2개 이하로 다른 비트 (복습필요)

### DIFF
--- a/Week03/cheonkyu/77885.py
+++ b/Week03/cheonkyu/77885.py
@@ -1,0 +1,43 @@
+def solution(numbers): # XOR
+    return [((num ^ (num+1)) >> 2) + num + 1 for num in numbers]
+
+# def to_str(n, base):
+#   converter = "0123456789ABCDEF"
+#   if n < base:
+#     return converter[n]
+#   else:
+#     return to_str(n // base, base) + converter[n % base]
+  
+# def solution(numbers):
+#     answer = []
+#     bits_dict = {}
+#     for n in numbers:
+#         i = n + 1
+#         # print(to_str(n, 2))
+#         while True:
+#             target = 0
+#             # print(bits_dict)
+#             if i in bits_dict:
+#                target = bits_dict[i]
+#             else:
+#                bits_dict[i] = to_str(i ^ n, 2).count('1')
+#                target = bits_dict[i]
+            
+#             if abs(target) <= 2:
+#                answer.append(i)
+#                break
+#             i += 1
+#     print(answer)
+#     return answer
+
+solution([15,127,179,3783,819199,9126805503,38588121087,8796093022207,17592186044415])
+# [3,11]
+# solution([312, 11, 7, 5, 3, 27, 75, 10, 12, 26, 324, 5236])
+# print(1000 ^ 1001)
+# 110
+
+# [31, 1] [47, 2]
+# [10] [11]
+# [53214] [53215]
+# [4321, 5324, 1111, 444, 666] [4322, 5325, 1115, 445, 667]
+# [312, 11, 7, 5, 3, 27, 75, 10, 12, 26, 324, 5236] [313, 13, 11, 6, 5, 29, 77, 11, 13, 27, 325, 5237]


### PR DESCRIPTION
## 문제 및 풀이과정

[문제명](2개 이하로 다른 비트)

소요시간: 60분

## 참고자료

시간 복잡도 이슈

다른 규칙을 적용

https://velog.io/@kerri/Python-프로그래머스Lv2-2개-이하로-다른-비트

```

1) 짝수의 경우
만약, 4라면 이진수로 100 입니다. 4보다 크면서 2개 이하로 다른 수를 찾으면 101 입니다.
즉, 가장 뒤에 있는 0을 1로 바꿔주면 됩니다.

2) 홀수의 경우
만약, 7이라면 이진수로 0111 (바꿀때 편의를 위해 앞에 0을 붙입니다)
먼저 짝수의 경우처럼 가장 뒤에 있는 0의 인덱스(idx)를 찾아 1로 바꿉니다. 그럼 1111 이 됩니다.
bin_number[idx] = '1'
그런 다음 idx+1 의 인덱스 값을 0으로 바꿉니다. 그럼 1011이 되고 답이 됩니다.
bin_number[idx+1] = '0'
```


---